### PR TITLE
Removed Language Support section

### DIFF
--- a/support/index.md
+++ b/support/index.md
@@ -299,28 +299,6 @@ The scripts use the cf command line interface to extract the following informati
   * Provisioned services
 
 
-## National language support for {{site.data.keyword.Bluemix_notm}}
-{: #lang}
-
-{{site.data.keyword.Bluemix_notm}} supports national languages other than English. However, not all of the content that is provided with {{site.data.keyword.Bluemix_notm}} is translated.
-The following table lists the supported national languages and language codes for {{site.data.keyword.Bluemix_notm}}.
-
-| **National language** | **Language code** |
-|-------------------|---------------|
-| Brazilian Portuguese | pt_BR |
-| English | en |
-| French | fr |
-| German | de |
-| Japanese | ja |
-| Korean | ko |
-| Italian | it |
-| Spanish | es |
-| Simplified Chinese | zh_CN |
-| Traditional Chinese | zh_TW |
-
-*Table 3. Supported national languages and language codes*
-
-
 ## Satisfaction surveys for {{site.data.keyword.Bluemix_notm}} support  
 {: #survey}
 


### PR DESCRIPTION
I have removed the language support section. It does not belong in the Contacting Support section because it is a statement of translation and not the languages in which technical support is offered.